### PR TITLE
FIxed comment error in workflow.

### DIFF
--- a/source/slackfred-files.py
+++ b/source/slackfred-files.py
@@ -42,7 +42,7 @@ def main(wf):
         filesList = wf.filter(query, filesList, key = searchSlackFiles)
 
     for files in filesList:
-        if files['comments_count'] > 0:
+        if 'initial_comment' in files:
             wf.add_item(title = files['name'],
                 subtitle = files['initial_comment']['comment'],
                 arg = files['url'],


### PR DESCRIPTION
Regarding #11 

This is the proper way to fix my issue. Just removing the comment support is incorrect because `comments_count` is a sum of all comments. But `initial_comment` is the comment given by the user when a file is first uploaded. That comment can be removed and "normal" comments can be added to the file. This gives the state of `comments_count > 0` but without any `initial_comment`.

Hope I'm making sense. This PR works perfectly for me.

Closes #11 