### PR TITLE
replace `webbrowser` with `open` command

### DIFF
--- a/source/slackfred.py
+++ b/source/slackfred.py
@@ -2,7 +2,7 @@ import sys
 import argparse
 from workflow import Workflow, web, PasswordNotFound
 import json
-import webbrowser
+import subprocess
 
 def slack_keys():
     wf = Workflow()
@@ -79,7 +79,7 @@ def main(wf):
 
     if args.open:
         url = slack_urlopen(wf.args[1])
-        webbrowser.open(url)
+        subprocess.call(['open', url])
         return
 
     if len(wf.args):


### PR DESCRIPTION
Instead of using the browser to forward the `slack://` uri to macosx, skip the browser entirely by using the native macosx `open` command.